### PR TITLE
Add handle by typeof

### DIFF
--- a/src/Polly.Net35/OrSyntax.cs
+++ b/src/Polly.Net35/OrSyntax.cs
@@ -11,11 +11,40 @@ namespace Polly
         /// Specifies the type of exception that this policy can handle.
         /// </summary>
         /// <typeparam name="TException">The type of the exception to handle.</typeparam>
-        /// <param name="policyBuilder">The current builder to chain off.</param>
+        /// <param name="policyBuilder"></param>
         /// <returns>The PolicyBuilder instance.</returns>
         public static PolicyBuilder Or<TException>(this PolicyBuilder policyBuilder) where TException : Exception
         {
             ExceptionPredicate predicate = exception => exception is TException;
+            policyBuilder.ExceptionPredicates.Add(predicate);
+            return policyBuilder;
+        }
+
+        /// <summary>
+        /// Specifies the type of exception that this policy can handle.
+        /// </summary>
+        /// <param name="policyBuilder">The current builder to chain off.</param>
+        /// <param name="expectedException">The type of the exception to handle.</param>
+        /// <returns>The PolicyBuilder instance.</returns>
+        public static PolicyBuilder Or(this PolicyBuilder policyBuilder, Type expectedException)
+        {
+            ExceptionPredicate predicate = exception => exception.GetType() == expectedException;
+            policyBuilder.ExceptionPredicates.Add(predicate);
+            return policyBuilder;
+        }
+
+        /// <summary>
+        /// Specifies the type of exception that this policy can handle with addition filters on this exception type.
+        /// </summary>
+        /// <param name="policyBuilder">The current builder to chain off.</param>
+        /// <param name="expectedException">The type of the exception to handle.</param>
+        /// <param name="exceptionPredicate">The exception predicate to filter the type of exception this policy can handle.</param>
+        /// <returns></returns>
+        public static PolicyBuilder Or(this PolicyBuilder policyBuilder, Type expectedException, Func<Exception, bool> exceptionPredicate)
+        {
+            ExceptionPredicate predicate = exception => exception.GetType() == expectedException
+                && exceptionPredicate(exception);
+            
             policyBuilder.ExceptionPredicates.Add(predicate);
             return policyBuilder;
         }

--- a/src/Polly.Net35/OrSyntax.cs
+++ b/src/Polly.Net35/OrSyntax.cs
@@ -11,7 +11,7 @@ namespace Polly
         /// Specifies the type of exception that this policy can handle.
         /// </summary>
         /// <typeparam name="TException">The type of the exception to handle.</typeparam>
-        /// <param name="policyBuilder"></param>
+        /// <param name="policyBuilder">The current builder to chain off.</param>
         /// <returns>The PolicyBuilder instance.</returns>
         public static PolicyBuilder Or<TException>(this PolicyBuilder policyBuilder) where TException : Exception
         {

--- a/src/Polly.Net35/Policy.cs
+++ b/src/Polly.Net35/Policy.cs
@@ -61,6 +61,32 @@ namespace Polly
         }
 
         /// <summary>
+        /// Specifies the type of exception that this policy can handle.
+        /// </summary>
+        /// <param name="exceptionType">The exception type expected.</param>
+        /// <returns>The PolicyBuilder instance.</returns>
+        public static PolicyBuilder Handle(Type exceptionType)
+        {
+            ExceptionPredicate predicate = exception => exception.GetType() == exceptionType;
+
+            return new PolicyBuilder(predicate);
+        }
+
+        /// <summary>
+        /// Specifies the type of exception that this policy can handle with addition filters on this exception type.
+        /// </summary>
+        /// <param name="exceptionType">The type of the exception.</param>
+        /// <param name="exceptionPredicate">The exception predicate to filter the type of exception this policy can handle.</param>
+        /// <returns>The PolicyBuilder instance.</returns>
+        public static PolicyBuilder Handle(Type exceptionType, Func<Exception, bool> exceptionPredicate)
+        {
+            ExceptionPredicate predicate = exception => exception.GetType() == exceptionType &&
+                exceptionPredicate(exception);
+
+            return new PolicyBuilder(predicate);
+        }
+
+        /// <summary>
         /// Specifies the type of exception that this policy can handle with addition filters on this exception type.
         /// </summary>
         /// <typeparam name="TException">The type of the exception.</typeparam>

--- a/src/Polly.Specs/PolicyAsyncSpecs.cs
+++ b/src/Polly.Specs/PolicyAsyncSpecs.cs
@@ -78,10 +78,42 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public async Task Executing_the_policy_action_for_typeof_exception_should_execute_the_specified_async_action()
+        {
+            bool executed = false;
+
+            Policy policy = Policy
+                .Handle(typeof(DivideByZeroException))
+                .RetryAsync((_, __) => { });
+
+            await policy.ExecuteAsync(() =>
+            {
+                executed = true;
+                return Task.FromResult(true) as Task;
+            });
+
+            executed.Should()
+                .BeTrue();
+        }
+
+        [Fact]
         public async Task Executing_the_policy_function_should_execute_the_specified_async_function_and_return_the_result()
         {
             Policy policy = Policy
                 .Handle<DivideByZeroException>()
+                .RetryAsync((_, __) => { });
+
+            int result = await policy.ExecuteAsync(() => Task.FromResult(2));
+
+            result.Should()
+                .Be(2);
+        }
+
+        [Fact]
+        public async Task Executing_the_policy_function_for_typeof_exception_should_execute_the_specified_async_function_and_return_the_result()
+        {
+            Policy policy = Policy
+                .Handle(typeof(DivideByZeroException))
                 .RetryAsync((_, __) => { });
 
             int result = await policy.ExecuteAsync(() => Task.FromResult(2));

--- a/src/Polly.Specs/PolicySpecs.cs
+++ b/src/Polly.Specs/PolicySpecs.cs
@@ -80,6 +80,35 @@ namespace Polly.Specs
 
             result.Should()
                   .Be(2);
-        } 
+        }
+
+
+        [Fact]
+        public void Executing_the_policy_function_for_typeof_should_execute_the_specified_function_and_return_the_result()
+        {
+            var executed = false;
+
+            var policy = Policy
+                          .Handle(typeof(DivideByZeroException))
+                          .Retry((_, __) => { });
+
+            policy.Execute(() => executed = true);
+
+            executed.Should()
+                    .BeTrue();
+        }
+
+        [Fact]
+        public void Executing_the_policy_function_for_exception_type_should_execute_the_specified_function_and_return_the_result()
+        {
+            var policy = Policy
+                          .Handle(typeof(DivideByZeroException))
+                          .Retry((_, __) => { });
+
+            var result = policy.Execute(() => 2);
+
+            result.Should()
+                  .Be(2);
+        }
     }
 }


### PR DESCRIPTION
Add method to allow you to handle policy by Type so you can pass in typeof().  This will make it easier for consuming libraries to configure what exceptions they are want to handle at run time based on config.

I've added some test coverage but did not want to repeat all tests for both generic and non generic methods.   