### PR TITLE
Action after final retry 

### DIFF
--- a/src/Polly.Net35/AfterFinalRetryFailureSyntax.cs
+++ b/src/Polly.Net35/AfterFinalRetryFailureSyntax.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Polly
+{
+    /// <summary>
+    /// Fluent API for defining an action to run after the final Retry. 
+    /// </summary>
+    public static partial class AfterFinalRetryFailureSyntax
+    {
+        /// <summary>
+        /// Sets the action to run after the final retry
+        /// </summary>
+        /// <returns></returns>
+        public static PolicyBuilder AfterFinalRetryFailure(this PolicyBuilder policyBuilder, Action<Exception> action)
+        {
+            policyBuilder.AfterFinalRetryFailureAction = action;
+            return policyBuilder;
+        }
+
+    }
+}

--- a/src/Polly.Net35/PolicyBuilder.cs
+++ b/src/Polly.Net35/PolicyBuilder.cs
@@ -17,12 +17,15 @@ namespace Polly
             {
                 exceptionPredicate
             };
+            AfterFinalRetryFailureAction = null;
         }
 
         internal IList<ExceptionPredicate> ExceptionPredicates
         {
             get { return _exceptionPredicates; }
         }
+
+        internal Action<Exception> AfterFinalRetryFailureAction { get; set; }
 
         #region Hide object members
 

--- a/src/Polly.Net35/Polly.Net35.csproj
+++ b/src/Polly.Net35/Polly.Net35.csproj
@@ -55,6 +55,7 @@
     <Compile Include="..\..\SolutionVersion.cs">
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
+    <Compile Include="AfterFinalRetryFailureSyntax.cs" />
     <Compile Include="CircuitBreakerSyntax.cs" />
     <Compile Include="CircuitBreaker\CircuitBreakerPolicy.cs" />
     <Compile Include="CircuitBreaker\CircuitBreakerState.cs" />

--- a/src/Polly.Net35/Retry/RetryPolicy.cs
+++ b/src/Polly.Net35/Retry/RetryPolicy.cs
@@ -6,7 +6,7 @@ namespace Polly.Retry
 {
     internal static partial class RetryPolicy
     {
-        public static void Implementation(Action action, IEnumerable<ExceptionPredicate> shouldRetryPredicates, Func<IRetryPolicyState> policyStateFactory)
+        public static void Implementation(Action action, IEnumerable<ExceptionPredicate> shouldRetryPredicates, Action<Exception> afterFinalRetryFailureAction, Func<IRetryPolicyState> policyStateFactory)
         {
             var policyState = policyStateFactory();
 
@@ -26,7 +26,14 @@ namespace Polly.Retry
 
                     if (!policyState.CanRetry(ex))
                     {
-                        throw;
+                        if (afterFinalRetryFailureAction != null)
+                        {
+                            afterFinalRetryFailureAction(ex);
+                        }
+                        else
+                        {
+                            throw;
+                        }
                     }
                 }
             }

--- a/src/Polly.Net35/RetrySyntax.cs
+++ b/src/Polly.Net35/RetrySyntax.cs
@@ -64,8 +64,9 @@ namespace Polly
 
             return new Policy(
                 action => RetryPolicy.Implementation(
-                    action, 
-                    policyBuilder.ExceptionPredicates, 
+                    action,
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyStateWithCount(retryCount, onRetry)));
         }
 
@@ -101,8 +102,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new ContextualPolicy((action, context) => RetryPolicy.Implementation(
-                action, 
-                policyBuilder.ExceptionPredicates, 
+                action,
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.AfterFinalRetryFailureAction,
                 () => new RetryPolicyStateWithCount(retryCount, onRetry, context)
             ));
         }
@@ -133,8 +135,9 @@ namespace Polly
 
             return new Policy(
                 action => RetryPolicy.Implementation(
-                    action, 
-                    policyBuilder.ExceptionPredicates, 
+                    action,
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyState(onRetry)));
         }
 
@@ -154,6 +157,7 @@ namespace Polly
             return new ContextualPolicy((action, context) => RetryPolicy.Implementation(
                 action, 
                 policyBuilder.ExceptionPredicates,
+                policyBuilder.AfterFinalRetryFailureAction,
                 () => new RetryPolicyState(onRetry, context)
             ));
         }
@@ -203,7 +207,8 @@ namespace Polly
             return new Policy(
                 action => RetryPolicy.Implementation(
                     action, 
-                    policyBuilder.ExceptionPredicates, 
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry)));
         }
 
@@ -236,7 +241,8 @@ namespace Polly
 
             return new ContextualPolicy((action, context) => RetryPolicy.Implementation(
                 action, 
-                policyBuilder.ExceptionPredicates, 
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.AfterFinalRetryFailureAction,
                 () => new RetryPolicyStateWithSleep(sleepDurations, onRetry, context)
             ));
         }
@@ -277,7 +283,8 @@ namespace Polly
             return new Policy(
                 action => RetryPolicy.Implementation(
                     action, 
-                    policyBuilder.ExceptionPredicates, 
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry)));
         }
 
@@ -303,7 +310,8 @@ namespace Polly
 
             return new ContextualPolicy((action, context) => RetryPolicy.Implementation(
                 action, 
-                policyBuilder.ExceptionPredicates, 
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.AfterFinalRetryFailureAction,
                 () => new RetryPolicyStateWithSleep(sleepDurations, onRetry, context)
             ));
         }

--- a/src/Polly.Net40/AfterFinalRetryFailureSyntax.cs
+++ b/src/Polly.Net40/AfterFinalRetryFailureSyntax.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Polly
+{
+    /// <summary>
+    /// Fluent API for defining an action to run after the final Retry. 
+    /// </summary>
+    public static partial class AfterFinalRetryFailureSyntax
+    {
+        /// <summary>
+        /// Sets the action to run after the final retry
+        /// </summary>
+        /// <returns></returns>
+        public static PolicyBuilder AfterFinalRetryFailure(this PolicyBuilder policyBuilder, Action<Exception> action)
+        {
+            policyBuilder.AfterFinalRetryFailureAction = action;
+            return policyBuilder;
+        }
+
+    }
+}

--- a/src/Polly.Net40/Polly.Net40.csproj
+++ b/src/Polly.Net40/Polly.Net40.csproj
@@ -108,6 +108,7 @@
     <Compile Include="..\Polly.Net35\Utilities\TimedLock.cs">
       <Link>Utilities\TimedLock.cs</Link>
     </Compile>
+    <Compile Include="AfterFinalRetryFailureSyntax.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Polly.Net45/AfterFinalRetryFailureSyntax.cs
+++ b/src/Polly.Net45/AfterFinalRetryFailureSyntax.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Polly
+{
+    /// <summary>
+    /// Fluent API for defining an action to run after the final Retry. 
+    /// </summary>
+    public static partial class AfterFinalRetryFailureSyntax
+    {
+        /// <summary>
+        /// Sets the action to run after the final retry
+        /// </summary>
+        /// <returns></returns>
+        public static PolicyBuilder AfterFinalRetryFailure(this PolicyBuilder policyBuilder, Action<Exception> action)
+        {
+            policyBuilder.AfterFinalRetryFailureAction = action;
+            return policyBuilder;
+        }
+
+    }
+}

--- a/src/Polly.Net45/Polly.Net45.csproj
+++ b/src/Polly.Net45/Polly.Net45.csproj
@@ -104,6 +104,7 @@
     <Compile Include="..\Polly.Net35\Utilities\TimedLock.cs">
       <Link>Utilities\TimedLock.cs</Link>
     </Compile>
+    <Compile Include="AfterFinalRetryFailureSyntax.cs" />
     <Compile Include="CircuitBreakerSyntaxAsync.cs" />
     <Compile Include="CircuitBreaker\CircuitBreakerPolicyAsync.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />

--- a/src/Polly.Net45/Retry/RetryPolicyAsync.cs
+++ b/src/Polly.Net45/Retry/RetryPolicyAsync.cs
@@ -8,8 +8,7 @@ namespace Polly.Retry
 {
     internal static partial class RetryPolicy
     {
-        public static async Task ImplementationAsync(Func<Task> action,
-            IEnumerable<ExceptionPredicate> shouldRetryPredicates, Func<IRetryPolicyState> policyStateFactory)
+        public static async Task ImplementationAsync(Func<Task> action, IEnumerable<ExceptionPredicate> shouldRetryPredicates, Action<Exception> afterFinalRetryFailureAction, Func<IRetryPolicyState> policyStateFactory)
         {
             IRetryPolicyState policyState = policyStateFactory();
 
@@ -30,7 +29,14 @@ namespace Polly.Retry
 
                     if (!policyState.CanRetry(ex))
                     {
-                        throw;
+                        if (afterFinalRetryFailureAction != null)
+                        {
+                            afterFinalRetryFailureAction(ex);
+                        }
+                        else
+                        {
+                            throw;
+                        }
                     }
                 }
             }

--- a/src/Polly.Net45/RetrySyntaxAsync.cs
+++ b/src/Polly.Net45/RetrySyntaxAsync.cs
@@ -67,6 +67,7 @@ namespace Polly
                 action => RetryPolicy.ImplementationAsync(
                     action,
                     policyBuilder.ExceptionPredicates,
+                    policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyStateWithCount(retryCount, onRetry))
                 );
         }
@@ -98,7 +99,7 @@ namespace Polly
             return new Policy(
                 action => RetryPolicy.ImplementationAsync(
                     action,
-                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.ExceptionPredicates, policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyState(onRetry))
                 );
         }
@@ -165,7 +166,7 @@ namespace Polly
             return new Policy(
                 action => RetryPolicy.ImplementationAsync(
                     action,
-                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.ExceptionPredicates, policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry))
                 );
         }
@@ -194,7 +195,7 @@ namespace Polly
             return new Policy(
                 action => RetryPolicy.ImplementationAsync(
                     action,
-                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.ExceptionPredicates, policyBuilder.AfterFinalRetryFailureAction,
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry))
                 );
         }

--- a/src/Polly.Pcl/AfterFinalRetryFailureSyntax.cs
+++ b/src/Polly.Pcl/AfterFinalRetryFailureSyntax.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Polly
+{
+    /// <summary>
+    /// Fluent API for defining an action to run after the final Retry. 
+    /// </summary>
+    public static partial class AfterFinalRetryFailureSyntax
+    {
+        /// <summary>
+        /// Sets the action to run after the final retry
+        /// </summary>
+        /// <returns></returns>
+        public static PolicyBuilder AfterFinalRetryFailure(this PolicyBuilder policyBuilder, Action<Exception> action)
+        {
+            policyBuilder.AfterFinalRetryFailureAction = action;
+            return policyBuilder;
+        }
+
+    }
+}

--- a/src/Polly.Pcl/Polly.Pcl.csproj
+++ b/src/Polly.Pcl/Polly.Pcl.csproj
@@ -101,6 +101,7 @@
     <Compile Include="..\Polly.Net45\Context.cs">
       <Link>Context.cs</Link>
     </Compile>
+    <Compile Include="AfterFinalRetryFailureSyntax.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Polly.Net45\CircuitBreaker\CircuitBreakerPolicyAsync.cs">
       <Link>CircuitBreaker\CircuitBreakerPolicyAsync.cs</Link>

--- a/src/Polly.Specs/AfterFinalRetryFailureSpecs.cs
+++ b/src/Polly.Specs/AfterFinalRetryFailureSpecs.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Common;
+using Polly.Specs.Helpers;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class AfterFinalRetryFailureSpecs
+    {
+
+
+        [Fact]
+        public void After_Final_Retry_Failure_Should_Happen_After_Final_Retry()
+        {
+            var didAfterFinalRetryFailureRunLast = false;
+            Policy.Handle<DivideByZeroException>()
+                .AfterFinalRetryFailure(ex => didAfterFinalRetryFailureRunLast = true)
+                .Retry(2, (exception, i) => didAfterFinalRetryFailureRunLast = false)
+                .Invoking(policy => policy.RaiseException<DivideByZeroException>(2+1))
+                .Invoke();
+
+            didAfterFinalRetryFailureRunLast.ShouldBeEquivalentTo(true);
+        }
+    }
+}

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\..\SolutionAssemblyInfo.cs">
       <Link>Properties\SolutionAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AfterFinalRetryFailureSpecs.cs" />
     <Compile Include="CircuitBreakerAsyncSpecs.cs" />
     <Compile Include="CircuitBreakerSpecs.cs" />
     <Compile Include="ContextualPolicySpecs.cs" />

--- a/src/Polly.Specs/RetryAsyncSpecs.cs
+++ b/src/Polly.Specs/RetryAsyncSpecs.cs
@@ -69,6 +69,19 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public void Should_not_throw_when_specified_exception_thrown_more_times_then_retry_count_and_after_final_retry_failure_action_defined()
+        {
+            var policy = Policy.Handle<DivideByZeroException>()
+                .AfterFinalRetryFailure(ex => { })
+                .RetryAsync(1);
+
+
+            policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(1 + 1))
+                  .ShouldNotThrow<DivideByZeroException>();
+        }
+
+
+        [Fact]
         public void Should_throw_when_specified_exception_thrown_more_times_then_retry_count()
         {
             var policy = Policy

--- a/src/Polly.Specs/RetrySpecs.cs
+++ b/src/Polly.Specs/RetrySpecs.cs
@@ -131,6 +131,18 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public void Should_not_throw_when_specified_exception_thrown_more_times_then_retry_count_and_after_final_retry_failure_action_defined()
+        {
+            var policy = Policy.Handle<DivideByZeroException>()
+                .AfterFinalRetryFailure(ex => { })
+                .Retry(1);
+
+
+            policy.Invoking(x => x.RaiseException<DivideByZeroException>(1 + 1))
+                  .ShouldNotThrow<DivideByZeroException>();
+        }
+
+        [Fact]
         public void Should_throw_when_specified_exception_thrown_more_times_then_retry_count()
         {
             var policy = Policy


### PR DESCRIPTION
Responding to a request (+ my own wishes)
https://github.com/michael-wolfenden/Polly/issues/31

Added a syntax to do an action after the final retry has failed

Policy.Handle()
.AfterFinalRetryFailure(ex => AfterFinalRetryLogic(ex))
.Retry(2)
..Execute(() => Logic());